### PR TITLE
feat(words): load words from API and update UI

### DIFF
--- a/client/src/app/entities/word/model/word.facade.ts
+++ b/client/src/app/entities/word/model/word.facade.ts
@@ -29,6 +29,7 @@ import {
   Observable,
   of,
   scan,
+  take,
   tap,
 } from 'rxjs';
 import { catchError } from 'rxjs/operators';
@@ -115,6 +116,17 @@ export class WordFacade {
 
     // 2. Если мы онлайн, идем за свежими данными на сервер
     this.syncManager.runSync();
+
+    this.wordApiService
+      .getAll()
+      .pipe(take(1))
+      .subscribe((words) => {
+        this.logger.warn('Мгновенно обновляем UI с сервера...');
+        const mappedWords = words.map((word) =>
+          WordMapper.toDomain({ ...word, synced: true, isDeleted: false }, owner),
+        );
+        this._words$.next(mappedWords);
+      });
   }
 
   public async createWord(data: CreateWordPayload): Promise<string | null> {


### PR DESCRIPTION
## What was done
- Added API request in loadAll() to fetch words from the server
- UI is now updated with server data after loading offline data

## Why
- To ensure the UI displays up-to-date data from the backend
- Complements existing offline-first behavior

## Details
- Uses take(1) to complete the subscription after the first response
- Maps API response to domain entities via WordMapper
- Keeps initial offline data rendering for faster UX